### PR TITLE
Feature 1.26-cohorts route returns desc array of obj

### DIFF
--- a/src/routes/cohorts/cohorts.controller.js
+++ b/src/routes/cohorts/cohorts.controller.js
@@ -12,7 +12,12 @@ const getCohorts = snapshot => {
     }
   }, {});
 
-  return cohorts;
+  return Object.keys(cohorts)
+    .map(key => ({
+      id: key,
+      applicants: cohorts[key]
+    }))
+    .sort((a, b) => -1 * a.id.localeCompare(b.id)); //returns sorted array in "desc" order
 };
 
 const cohortsController = (req, res) => {

--- a/src/routes/cohorts/cohorts.controller.js
+++ b/src/routes/cohorts/cohorts.controller.js
@@ -17,7 +17,7 @@ const getCohorts = snapshot => {
       id: key,
       applicants: cohorts[key]
     }))
-    .sort((a, b) => -1 * a.id.localeCompare(b.id)); //returns sorted array in "desc" order
+    .sort((a, b) => (parseInt(a.slice(7)) > parseInt(b.slice(7)) ? -1 : 1)); //returns sorted array in "desc" order
 };
 
 const cohortsController = (req, res) => {

--- a/src/routes/cohorts/cohorts.controller.js
+++ b/src/routes/cohorts/cohorts.controller.js
@@ -17,7 +17,9 @@ const getCohorts = snapshot => {
       id: key,
       applicants: cohorts[key]
     }))
-    .sort((a, b) => (parseInt(a.slice(7)) > parseInt(b.slice(7)) ? -1 : 1)); //returns sorted array in "desc" order
+    .sort((a, b) =>
+      parseInt(a.id.slice(7)) > parseInt(b.id.slice(7)) ? -1 : 1
+    ); //returns sorted array in "desc" order
 };
 
 const cohortsController = (req, res) => {


### PR DESCRIPTION
the data returned from "/cohorts/" route will look like this now:
```
{
    "data": [
        {
            "id": "cohort-8",
            "applicants": 43
        },
        {
            "id": "cohort-7",
            "applicants": 44
        },
        {
            "id": "cohort-6",
            "applicants": 43
        }
    ]
}
```