### PR TITLE
Feat/2.3 add cohort total applicants

### DIFF
--- a/src/routes/cohorts/cohorts.controller.js
+++ b/src/routes/cohorts/cohorts.controller.js
@@ -26,12 +26,12 @@ const cohortsController = (req, res) => {
   db.collection('application_data')
     .get()
     .then(snapshot => {
-      res.json({
+      res.status(200).json({
         data: getCohorts(snapshot)
       });
     })
     .catch(error => {
-      res.json({ error });
+      res.status(400).json({ error });
     });
 };
 

--- a/src/routes/cohorts/singleCohort.controller.js
+++ b/src/routes/cohorts/singleCohort.controller.js
@@ -52,6 +52,32 @@ const getGraphData = snapshot => {
   return graphValues;
 };
 
+const getAnswered = snapshot => {
+  const values = snapshot.docs.reduce(
+    (acc, currentDoc) => {
+      const resolvedDoc = currentDoc.data();
+      acc.gender = resolvedDoc.gender ? acc.gender + 1 : acc.gender;
+      acc.minorityGroup = resolvedDoc.minority_group
+        ? acc.minorityGroup + 1
+        : acc.minorityGroup;
+      acc.previousBootcamp = resolvedDoc.previous_bootcamp
+        ? acc.previousBootcamp + 1
+        : acc.previousBootcamp;
+      acc.employmentStatus = resolvedDoc.employment_status
+        ? acc.employmentStatus + 1
+        : acc.employmentStatus;
+      return acc;
+    },
+    {
+      gender: 0,
+      minorityGroup: 0,
+      previousBootcamp: 0,
+      employmentStatus: 0
+    }
+  );
+  return values;
+};
+
 const singleCohortController = (req, res) => {
   const cohortId = 'cohort-' + req.params.id;
   let singleCohort = db.collection('application_data');
@@ -62,7 +88,8 @@ const singleCohortController = (req, res) => {
       res.status(200).json({
         data: {
           id: cohortId,
-          applicants: snapshot.docs.length,
+          totalApplicants: snapshot.docs.length,
+          applicantsAnswered: getAnswered(snapshot),
           ...getGraphData(snapshot)
         }
       });

--- a/src/routes/cohorts/singleCohort.controller.js
+++ b/src/routes/cohorts/singleCohort.controller.js
@@ -59,12 +59,16 @@ const singleCohortController = (req, res) => {
     .where('cohort', '==', cohortId)
     .get()
     .then(snapshot => {
-      res
-        .status(200)
-        .json({ data: { id: cohortId, ...getGraphData(snapshot) } });
+      res.status(200).json({
+        data: {
+          id: cohortId,
+          applicants: snapshot.docs.length,
+          ...getGraphData(snapshot)
+        }
+      });
     })
     .catch(error => {
-      res.json({ error });
+      res.status(400).json({ error });
     });
 };
 


### PR DESCRIPTION
Added data to singleCohort that will support the new feature of showing the number of applicants that have answered. 

The reason I added the data of the number of applicants to this data as well is that when you access the specific cohort page directly the data about the cohorts in general is not available because we don't fetch it here. so I had two choices: 
1) fetch the data on the cohort page as well (though it's going to be overkill).
2) get the data when we fetch a single cohort. 

![image](https://user-images.githubusercontent.com/52331753/70572938-d14c1c00-1b6e-11ea-9ce1-2bbea0601da2.png)

